### PR TITLE
Improve Javadoc comment for the view method in `TaskList`

### DIFF
--- a/src/main/java/mike/TaskList.java
+++ b/src/main/java/mike/TaskList.java
@@ -10,9 +10,9 @@ import mike.task.Task;
  */
 public class TaskList extends ArrayList<Task> {
     /**
-     * Filters the view of the task list to tasks permitted by ListView object.
+     * Returns a filtered view of the task list to tasks permitted by the ListView object.
      * @param listView
-     * @return string representation of filtered task list.
+     * @return Filtered task list represented as a String.
      */
     public String view(ListView listView) {
         return this


### PR DESCRIPTION
The Javadoc comment for view was not descriptive enough.

Editing the Javadoc comment to be more descriptive is a small step in improving the overall code quality of the project. This will be beneficial for future developments.

Let us change 'Filters' to 'Returns' and improve the grammar of the sentence.

It is customary for the Javadoc comment of return statements to start with the word 'Returns', a verb.